### PR TITLE
fix inside list items containing block elements in Firefox

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -98,12 +98,14 @@ strong {
 }
 
 ul li {
-  list-style: inside;
+  list-style-position: inside;
+  list-style: disc;
   padding-left: 25px;
 }
 
 ol li {
-  list-style: decimal inside;
+  list-style-position: inside;
+  list-style: decimal;
   padding-left: 20px;
 }
 


### PR DESCRIPTION
There is an issue with Firefox and list items that include block elements, such as paragraphs and the inside property (according to http://stackoverflow.com/questions/1142314/css-rendering-inconsistency-on-ul-with-firefox-being-the-odd-ball-out).

This fixes the issue.
