### PR TITLE
remove fixed font size in <code> and <pre>

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -156,7 +156,6 @@ img {
 
 code, pre {
 	font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
-  font-size:14px;
 }
 
 pre {


### PR DESCRIPTION
Having a fixed font-size for `<code>` and `<pre>` makes it harder to use it in headings.

I think it is better to remove the fixed font-size to enable typing where the user wants (see <http://www.handlecsv.tk>).